### PR TITLE
Start documenting international regulations on vehicle window transparency.

### DIFF
--- a/international-regulations-on-vehicle-window-transparency.md
+++ b/international-regulations-on-vehicle-window-transparency.md
@@ -1,0 +1,15 @@
+### 各國車窗透光率法規
+### International Regulations on Vehicle Window Transparency
+
+| | 國家<br>Country | 地區<br>Region| Front<br>&nbsp; | Front<br>Side | Rear<br>Side | Rear<br>&nbsp; | Sources<br>&nbsp; |
+|:--|:--|:--|-:|--:|--:|--:|:--|
+| 🇦🇺 | 澳洲<br>Australia | 澳洲首都領地<br>Australian Capital Territory | 100% | 35% | 20% | 20% | [1](https://australiatintlaws.com/) |
+| | | 新南威爾斯州<br>New South Wales | 100% | 35% | 20% | 20% | [1](https://australiatintlaws.com/) |
+| | | 北領地<br>Northern Territory | 100% | 35% | 15% | 15% | [1](https://australiatintlaws.com/) |
+| | | 昆士蘭州<br>Queensland | 100% | 35% | 20% | 20% | [1](https://australiatintlaws.com/) |
+| | | 南澳州<br>South Australia | 100% | 35% | 20% | 20% | [1](https://australiatintlaws.com/) |
+| | | 塔斯馬尼亞州<br>Tasmania | 70% | 35% | 20% | 20% | [1](https://australiatintlaws.com/) |
+| | | 維多利亞州<br>Victoria | 100% | 35% | 20% | 20% | [1](https://australiatintlaws.com/) |
+| | | 西澳州<br>Western Australia | 100% | 35% | 20% | 20% | [1](https://australiatintlaws.com/) |
+| 🇳🇿 | 紐西蘭<br>New Zealand | | 100% | 35% | 35% | 35% | [1](https://www.nzta.govt.nz/vehicles/warrants-and-certificates/vehicle-equipment/vehicle-windows-wipers-and-mirrors/)|
+| 🇬🇧 | 英國<br>United Kingdom | | 75% | 70% | 0% | 0% | [1](https://www.gov.uk/tinted-vehicle-window-rules) |


### PR DESCRIPTION
To begin with, we just include the following countries:
- Australia
- New Zealand
- United Kingdom

In future, we can add more countries to this table, and update it as regulations change.